### PR TITLE
bugfix: keep LUT information if channels stay channels

### DIFF
--- a/src/main/java/fiji/stacks/Hyperstack_rearranger.java
+++ b/src/main/java/fiji/stacks/Hyperstack_rearranger.java
@@ -172,7 +172,11 @@ public class Hyperstack_rearranger implements PlugIn
 		newImp.setCalibration( imp.getCalibration() );
 		
 		final CompositeImage c = new CompositeImage( newImp, CompositeImage.COMPOSITE );
-		
+		if (targetChannels == 0) //if channels stay channels
+		{
+			c.setLuts(imp.getLuts());
+		}
+
 		if ( closeOldImp )
 			imp.close();
 		


### PR DESCRIPTION
Bugfix: When applying the "Re-order Hyperstack" plugin, LUT information was lost. If the stack was grey before, it is red afterwards. 

This commit changes this behaviour: If channels stay channels when reordering, the LUTs are copied over from the old to the new image.
